### PR TITLE
[HW-8] k8s monitoring

### DIFF
--- a/kubernetes-monitoring/configMap.yaml
+++ b/kubernetes-monitoring/configMap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen       8000;
+
+        location / {
+          add_header Content-Type text/html;
+          return 200 '<html><body><h1>Homework 8</h1></body></hmtl>';
+        }
+
+        location /healthz {
+          return 200 'alive\n';
+          add_header Content-Type text/plain;
+          access_log off;
+        }
+
+        location ~ /stub-status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+      }
+    }

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-monitoring
+  namespace: homework
+  labels: &labels
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: homework
+spec:
+  replicas: 1
+  selector:
+    matchLabels: *labels
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+      containers:
+        - name: nginx
+          image: nginx:1.28.0-alpine-slim
+          command:
+            - nginx
+            - '-g'
+            - daemon off;
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            failureThreshold: 3
+        - name: nginx-exporter
+          image: nginx/nginx-prometheus-exporter:1.4.2
+          args:
+            - '-nginx.scrape-uri=http://127.0.0.1:8000/stub-status'
+          ports:
+            - name: metrics
+              containerPort: 9113
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi

--- a/kubernetes-monitoring/namespace.yaml
+++ b/kubernetes-monitoring/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+  labels:
+    app.kubernetes.io/instance: homework

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: homework
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: homework
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+    - name: metrics
+      protocol: TCP
+      port: 9100
+      targetPort: metrics
+  type: ClusterIP

--- a/kubernetes-monitoring/serviceMonitor.yaml
+++ b/kubernetes-monitoring/serviceMonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: monitoring
+  name: homework
+  namespace: homework
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 3s
+  namespaceSelector:
+    matchNames:
+      - homework
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: homework


### PR DESCRIPTION
# Выполнено ДЗ № 8

 - [x] Основное ДЗ

## В процессе сделано:
 - установил prometheus-operator через helm chart
   ```shell
    helm install monitoring -n monitoring --create-namespace prometheus-community/kube-prometheus-stack
   ```
 - создал манифесты namespace.yaml, configMap.yaml, deployment.yaml, service.yaml, сконфигурированные так что на порту 9100 сервиса доступны метрики nginx в формате prometheus которые собирает nginx-exporter
 - создал манифест serviceMonitor.yaml для сбора метрик с помощью prometheus.

## Как запустить проект:
 - установить prometheus-operator
    ```shell
    helm install monitoring -n monitoring --create-namespace prometheus-community/kube-prometheus-stack
   ```
- в директории kubernetes-monitoring выполнить команду:
    ```shell
    kubectl apply -f namespace.yaml -f configMap.yaml -f deployment.yaml -f service.yaml -f serviceMonitor.yaml
    ```

## Как проверить работоспособность:
 - зайти в UI prometheus через port-forwarding и убедится в наличии метрик nginx
 
![image](https://github.com/user-attachments/assets/239caf5f-0cb0-4ec2-a830-b8ac85cc9a15)


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
